### PR TITLE
Adding proper json prerequisites and json dump to add_shares.

### DIFF
--- a/lib/linked_in/share_and_social_stream.rb
+++ b/lib/linked_in/share_and_social_stream.rb
@@ -84,7 +84,7 @@ module LinkedIn
     def add_share(share)
       path = "/people/~/shares"
       defaults = {visibility: {code: "anyone"}}
-      post(path, defaults.merge(share))
+      post(path, MultiJson.dump(defaults.merge(share)), "Content-Type" => "application/json")
     end
 
     # Create a comment on an update from the authenticated user


### PR DESCRIPTION
Something's making me think that the LinkedIn gem is outdated. In any case, I just updated this gem to be able to add_shares again.

We should probably look into remerging the entire LinkedIn gem again though.
