### PR TITLE
dont conflict with twitter library

### DIFF
--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -48,6 +48,7 @@ module LinkedIn
     def_delegators :@communications, :send_message
 
     def_delegators :@share_and_social_stream, :shares,
+                                              :share,
                                               :add_share,
                                               :like_share,
                                               :share_likes,

--- a/lib/linked_in/connection.rb
+++ b/lib/linked_in/connection.rb
@@ -1,5 +1,3 @@
-Faraday::Response.register_middleware :raise_error_orig => Faraday::Response::RaiseError
-
 module LinkedIn
   # Used to perform requests against LinkedIn's API.
   class Connection < ::Faraday::Connection
@@ -19,7 +17,7 @@ module LinkedIn
       # the same param to certain endpoints (like the search API).
       self.options.params_encoder = ::Faraday::FlatParamsEncoder
 
-      self.response :raise_error_orig
+      self.response :linkedin_raise_error
     end
 
 

--- a/lib/linked_in/errors.rb
+++ b/lib/linked_in/errors.rb
@@ -5,6 +5,9 @@ module LinkedIn
 
   # Raised when we know requests will be malformed
   class InvalidRequest < StandardError; end
+  
+  # Raised when we get a throttle error from the API
+  class ThrottleError < StandardError; end
 
   # Raised when LinkedIn returns a non 400+ status code during an OAuth
   # request.
@@ -21,7 +24,8 @@ module LinkedIn
                   :no_auth_code,
                   :no_access_token,
                   :credentials_missing,
-                  :redirect_uri_mismatch
+                  :redirect_uri_mismatch,
+                  :throttled
     end
 
     @deprecated = "This has been deprecated by LinkedIn. Check https://developer.linkedin.com to see the latest available API calls"
@@ -34,6 +38,12 @@ module LinkedIn
 
     @credentials_missing = "Client credentials do not exist. Please either pass your client_id and client_secret to the LinkedIn::Oauth.new constructor or set them via LinkedIn.configure"
 
-    @redirect_uri_mismatch = "Your redirect_uri must be exactly the same as the one used to generated your auth code url"
+    @redirect_uri_mismatch = "Throttle limit for calls to this resource is reached"
+    
+    def klass
+      
+    end
+    
+    
   end
 end

--- a/lib/linked_in/raise_error.rb
+++ b/lib/linked_in/raise_error.rb
@@ -1,0 +1,16 @@
+require 'faraday'
+
+module LinkedIn
+  class RaiseError < Faraday::Response::RaiseError
+    def on_complete(response)
+      status_code = response.status.to_i
+      if status_code == 403 && response.body =~ /throttle/i
+        raise LinkedIn::ThrottleError
+      else
+        super
+      end
+    end
+  end
+end
+
+Faraday::Response.register_middleware :linkedin_raise_error => LinkedIn::RaiseError

--- a/lib/linked_in/share_and_social_stream.rb
+++ b/lib/linked_in/share_and_social_stream.rb
@@ -38,6 +38,11 @@ module LinkedIn
       path = "#{profile_path(options)}/network/updates"
       get(path, {type: "SHAR", scope: "self"}.merge(options))
     end
+    
+    def share(update_key, options={})
+      path = "#{profile_path(options)}/network/updates/key=#{update_key}"
+      get(path)
+    end
 
     # Retrieve all comments for a particular network update
     #

--- a/lib/linkedin-oauth2.rb
+++ b/lib/linkedin-oauth2.rb
@@ -1,6 +1,7 @@
 require "oauth2"
 
 require "linked_in/errors"
+require "linked_in/raise_error"
 require "linked_in/version"
 require "linked_in/configuration"
 

--- a/spec/linked_in/api/share_and_social_stream_spec.rb
+++ b/spec/linked_in/api/share_and_social_stream_spec.rb
@@ -57,4 +57,17 @@ describe LinkedIn::ShareAndSocialStream do
     expect(response.body).to eq ""
     expect(response.status).to eq 201
   end
+  
+  context 'throttling' do
+    it 'throws the right exception' do
+      stub_request(:post, "https://api.linkedin.com/v1/people/~/shares?oauth2_access_token=#{access_token}")
+        .to_return(
+          body: "{\n  \"errorCode\": 0,\n  \"message\": \"Throttle limit for calls to this resource is reached.\",\n  \"requestId\": \"M784AXE9MJ\",\n  \"status\": 403,\n  \"timestamp\": 1412871058321\n}",
+          status: 403
+        )
+        
+      err_msg = LinkedIn::ErrorMessages.throttled
+      expect {api.add_share(:comment => "Testing, 1, 2, 3")}.to raise_error(LinkedIn::ThrottleError, err_msg)
+    end
+  end
 end


### PR DESCRIPTION
Without this patch, if I have the twitter gem loaded in my app at the same time as this one, the LinkedIn faraday connection ends up with `Twitter::REST::Response::RaiseError` in its middleware chain rather than the `Faraday::Response::RaiseError` that it's expecting. The corresponding registration in the twitter gem is in the file `lib/twitter/rest/response/raise_error.rb`

I've looked inside faraday and it seems like these registrations should be scoped to the subclasses that each library makes for itself, but that's clearly not happening here. All in all the whole thing is ungodly complicated considering it just makes HTTP requests, there's a mutex controlling access to some kind of structure containing various constants that the library has modified, (I think) and basically I'm not interested in touching any of it with a ten foot pole. (I'm sure it's very heavy duty code and its like that for a good reason but I just don't have the time to wade into it.)

This patch doesn't break any tests so I'm leaving it here in case anyone has the same problem.
