### PR TITLE
Increase visibility of LinkedIn REST errors

### DIFF
--- a/lib/linked_in/errors.rb
+++ b/lib/linked_in/errors.rb
@@ -9,6 +9,12 @@ module LinkedIn
   # Raised when we get a throttle error from the API
   class ThrottleError < StandardError; end
 
+  # Raised When LinkedIn request params are missing
+  class ArgumentError < StandardError; end
+
+  # Raised When LinkedIn returns a 403 for a REST API call
+  class PermissionsError < StandardError; end
+
   # Raised when LinkedIn returns a non 400+ status code during an OAuth
   # request.
   class OAuthError < OAuth2::Error; end

--- a/lib/linked_in/errors.rb
+++ b/lib/linked_in/errors.rb
@@ -45,6 +45,12 @@ module LinkedIn
     @credentials_missing = "Client credentials do not exist. Please either pass your client_id and client_secret to the LinkedIn::Oauth.new constructor or set them via LinkedIn.configure"
 
     @redirect_uri_mismatch = "Throttle limit for calls to this resource is reached"
+
+    @arguments_malformed = "The arguments for this REST API call are malformed"
+
+    @argument_missing = "An argument is missing for this REST API call"
+
+    @not_permitted = "This user is not permitted to make this REST API call"
     
     def klass
       

--- a/lib/linked_in/raise_error.rb
+++ b/lib/linked_in/raise_error.rb
@@ -5,7 +5,17 @@ module LinkedIn
     def on_complete(response)
       status_code = response.status.to_i
       if status_code == 403 && response.body =~ /throttle/i
-        raise LinkedIn::ThrottleError
+        fail LinkedIn::ThrottleError
+      elsif [400,403].include?(status_code)
+        body = MultiJson.load(response.body)
+
+        if status_code == 400 && response.body =~ /is missing/i        
+          fail LinkedIn::ArgumentError, body['message'] || LinkedIn::ErrorMessages.argument_missing
+        elsif status_code == 400
+          fail LinkedIn::InvalidRequest, body['message'] || LinkedIn::ErrorMessages.arguments_malformed
+        else # status_code == 403
+          fail LinkedIn::PermissionsError, body['message'] || LinkedIn::ErrorMessages.not_permitted
+        end
       else
         super
       end

--- a/spec/linked_in/api/share_and_social_stream_spec.rb
+++ b/spec/linked_in/api/share_and_social_stream_spec.rb
@@ -57,7 +57,37 @@ describe LinkedIn::ShareAndSocialStream do
     expect(response.body).to eq ""
     expect(response.status).to eq 201
   end
+
+  context 'argument missing' do
+    it "throws the right exception" do
+      stub_request(:post, "https://api.linkedin.com/v1/people/~/shares?oauth2_access_token=#{access_token}").to_return(
+          body: "{\n  \"errorCode\": 0,\n  \"message\": \"submitted-url is missing\",\n  \"requestId\": \"M784AXE9MJ\",\n  \"status\": 400,\n  \"timestamp\": 1412871058321\n}",
+          status: 400
+        )
+      expect {api.add_share(comment: "Testing, 1, 2, 3")}.to raise_error(LinkedIn::ArgumentError)
+    end
+  end
+
+  context 'invalid request - arguments malformed' do
+    it "throws the right exception" do
+      stub_request(:post, "https://api.linkedin.com/v1/people/~/shares?oauth2_access_token=#{access_token}").to_return(
+          body: "{\n  \"errorCode\": 0,\n  \"message\": \"\",\n  \"requestId\": \"M784AXE9MJ\",\n  \"status\": 400,\n  \"timestamp\": 1412871058321\n}",
+          status: 400
+        )
+      expect {api.add_share(:comment => "Testing, 1, 2, 3")}.to raise_error(LinkedIn::InvalidRequest)
+    end
+  end
   
+  context 'action not permitted for this user' do
+    it "throws the right exception" do
+      stub_request(:post, "https://api.linkedin.com/v1/people/~/shares?oauth2_access_token=#{access_token}").to_return(
+          body: "{\n  \"errorCode\": 0,\n  \"message\": \"\",\n  \"requestId\": \"M784AXE9MJ\",\n  \"status\": 403,\n  \"timestamp\": 1412871058321\n}",
+          status: 403
+        )
+      expect {api.add_share(:comment => "Testing, 1, 2, 3")}.to raise_error(LinkedIn::PermissionsError)
+    end
+  end
+
   context 'throttling' do
     it 'throws the right exception' do
       stub_request(:post, "https://api.linkedin.com/v1/people/~/shares?oauth2_access_token=#{access_token}")


### PR DESCRIPTION
I had a hard time getting started with the linkedin-oauth2 gem because I couldn't see what errors LinkedIn was getting.  Just seeing a 400 or 403 was too opaque for me, so I extended the raise_error class to throw specific errors on a 400 or a 403.

I hope that exposing the errors can save new users some trouble and allow them to quickly get their apps working.
