### PR TITLE
Implement requesting specific fields when retrieving company page

### DIFF
--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -66,6 +66,7 @@ module LinkedIn
       @companies = LinkedIn::Companies.new(@connection)
       @communications = LinkedIn::Communications.new(@connection)
       @share_and_social_stream = LinkedIn::ShareAndSocialStream.new(@connection)
+      @organizations = LinkedIn::Organizations.new(@connection)
     end
 
     def default_params

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -54,6 +54,7 @@ module LinkedIn
     def_delegators :@share_and_social_stream, :add_text_share
 
     def_delegators :@organizations, :organization_access
+                                    :organization
 
     private ##############################################################
 

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -53,6 +53,8 @@ module LinkedIn
 
     def_delegators :@share_and_social_stream, :add_text_share
 
+    def_delegators :@organizations, :organization_access
+
     private ##############################################################
 
     def initialize_endpoints

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -51,15 +51,7 @@ module LinkedIn
 
     def_delegators :@communications, :send_message
 
-    def_delegators :@share_and_social_stream, :shares,
-                                              :share,
-                                              :add_share,
-                                              :like_share,
-                                              :share_likes,
-                                              :unlike_share,
-                                              :share_comments,
-                                              :update_comment,
-                                              :network_updates
+    def_delegators :@share_and_social_stream, :add_text_share
 
     private ##############################################################
 

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -74,13 +74,11 @@ module LinkedIn
     end
 
     def default_params
-      # https//developer.linkedin.com/documents/authentication
-      return {oauth2_access_token: @access_token.token}
+      {}
     end
 
     def default_headers
-      # https://developer.linkedin.com/documents/api-requests-json
-      return {"x-li-format" => "json"}
+      { "Authorization" => "Bearer #{@access_token.token}" }
     end
 
     def verify_access_token!(access_token)

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -24,7 +24,8 @@ module LinkedIn
                              :skills,
                              :connections,
                              :picture_urls,
-                             :new_connections
+                             :new_connections,
+                             :me
 
     def_delegators :@search, :search
 

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -53,7 +53,7 @@ module LinkedIn
 
     def_delegators :@share_and_social_stream, :add_text_share
 
-    def_delegators :@organizations, :organization_access
+    def_delegators :@organizations, :organization_access,
                                     :organization
 
     private ##############################################################

--- a/lib/linked_in/api_resource.rb
+++ b/lib/linked_in/api_resource.rb
@@ -114,6 +114,10 @@ module LinkedIn
       end
     end
 
+    def me_path
+      path = "/me"
+    end
+
     def profile_path(options={}, allow_multiple=true)
       path = "/people"
 

--- a/lib/linked_in/api_resource.rb
+++ b/lib/linked_in/api_resource.rb
@@ -115,7 +115,7 @@ module LinkedIn
     end
 
     def me_path
-      path = "/me"
+      "/me"
     end
 
     def profile_path(options={}, allow_multiple=true)

--- a/lib/linked_in/companies.rb
+++ b/lib/linked_in/companies.rb
@@ -23,6 +23,7 @@ module LinkedIn
     # @option options [String] :type
     # @option options [String] :count
     # @option options [String] :start
+    # @option options [String] :profile_fields
     # @return [LinkedIn::Mash]
     def company(options = {})
       path = company_path(options)
@@ -182,7 +183,11 @@ module LinkedIn
       if domain = options.delete(:domain)
         path += "?email-domain=#{CGI.escape(domain)}"
       elsif id = options.delete(:id)
-        path += "/#{id}"
+        if profile_fields = options.delete(:profile_fields)
+          path += "/#{id}:(#{profile_fields})"
+        else
+          path += "/#{id}"
+        end
       elsif url = options.delete(:url)
         path += "/url=#{CGI.escape(url)}"
       elsif name = options.delete(:name)

--- a/lib/linked_in/configuration.rb
+++ b/lib/linked_in/configuration.rb
@@ -32,7 +32,7 @@ module LinkedIn
 
     def initialize
       @api = "https://api.linkedin.com"
-      @api_version = "/v1"
+      @api_version = "/v2"
       @site = "https://www.linkedin.com"
       @token_url = "/uas/oauth2/accessToken"
       @authorize_url = "/uas/oauth2/authorization"

--- a/lib/linked_in/organizations.rb
+++ b/lib/linked_in/organizations.rb
@@ -1,11 +1,25 @@
 module LinkedIn
 
   class Organizations < APIResource
+
     # Retrieves a member's organization access control information
     def organization_access(options={})
-      path = "/organizationAcls?q=roleAssignee"
+      path = "/organizationAcls?q=roleAssignee&projection=(elements*(*,organization~(localizedName)))"
       get(path, options)
     end
-  end
+
+    # Retrieves an organization
+    def organization(options={})
+      path = organization_path(options)
+      get(path, options)
+    end
+
+    def organization_path(options)
+      path = "/organizations"
+
+      if id = options.delete(:id)
+        path += "/#{id}"
+      end
+    end
 
 end

--- a/lib/linked_in/organizations.rb
+++ b/lib/linked_in/organizations.rb
@@ -22,4 +22,6 @@ module LinkedIn
       end
     end
 
+  end
+
 end

--- a/lib/linked_in/organizations.rb
+++ b/lib/linked_in/organizations.rb
@@ -1,0 +1,11 @@
+module LinkedIn
+
+  class Organizations < APIResource
+    # Retrieves a member's organization access control information
+    def organization_access(options={})
+      path = "/organizationAcls?q=roleAssignee"
+      get(path, options)
+    end
+  end
+
+end

--- a/lib/linked_in/people.rb
+++ b/lib/linked_in/people.rb
@@ -103,15 +103,6 @@ module LinkedIn
     end
 
 
-    protected ############################################################
-
-
-    def get(path, options)
-      options[:"secure-urls"] = true unless options[:secure] == false
-      super path, options
-    end
-
-
     private ##############################################################
 
 

--- a/lib/linked_in/people.rb
+++ b/lib/linked_in/people.rb
@@ -39,6 +39,11 @@ module LinkedIn
       get(path, options)
     end
 
+    def me(options={})
+      path = me_path
+      get(path, options)
+    end
+
     # Retrieve a list of 1st degree connections for a user who has
     # granted access to his/her account
     #
@@ -95,7 +100,7 @@ module LinkedIn
       options = parse_id(id, options)
       path = "#{profile_path(options, false)}/skills"
       get(path, options)
-    end     
+    end
 
 
     protected ############################################################

--- a/lib/linked_in/share_and_social_stream.rb
+++ b/lib/linked_in/share_and_social_stream.rb
@@ -28,7 +28,7 @@ module LinkedIn
           "com.linkedin.ugc.MemberNetworkVisibility" => "PUBLIC"
         }
       }
-      post(path, params.to_json, "Content-Type" => "application/json")
+      post(path, params.to_json, { "Content-Type" => "application/json", "X-Restli-Protocol-Version" => "2.0.0" })
     end
   end
 end

--- a/lib/linked_in/share_and_social_stream.rb
+++ b/lib/linked_in/share_and_social_stream.rb
@@ -1,133 +1,34 @@
 module LinkedIn
-  # Share and Social Stream APIs
+  # Share APIs
   #
-  # @see http://developer.linkedin.com/documents/share-and-social-stream
-  # @see http://developer.linkedin.com/documents/share-api Share API
+  # @see https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/share-on-linkedin
   #
-  # The following API actions do not have corresponding methods in
-  # this module
-  #
-  #   * GET Network Statistics
-  #   * POST Post Network Update
-  #
-  # [(contribute here)](https://github.com/emorikawa/linkedin-oauth2)
   class ShareAndSocialStream < APIResource
-    # Retrieve the authenticated users network updates
+    # Create a text share for the authenticated user
     #
-    # Permissions: rw_nus
+    # Permissions: w_member_social
     #
-    # @see http://developer.linkedin.com/documents/get-network-updates-and-statistics-api
-    # @see http://developer.linkedin.com/documents/network-update-types Network Update Types
+    # @see https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/share-on-linkedin#create-a-text-share
     #
-    # @macro profile_options
-    # @option options [String] :scope
-    # @option options [String] :type
-    # @option options [String] :count
-    # @option options [String] :start
-    # @option options [String] :after
-    # @option options [String] :before
-    # @option options [String] :show-hidden-members
-    # @return [LinkedIn::Mash]
-    def network_updates(options={})
-      path = "#{profile_path(options)}/network/updates"
-      get(path, options)
-    end
-
-    # TODO refactor to use #network_updates
-    def shares(options={})
-      path = "#{profile_path(options)}/network/updates"
-      get(path, {type: "SHAR", scope: "self"}.merge(options))
-    end
-    
-    def share(update_key, options={})
-      path = "#{profile_path(options)}/network/updates/key=#{update_key}"
-      get(path)
-    end
-
-    # Retrieve all comments for a particular network update
-    #
-    # @note The first 5 comments are included in the response to #network_updates
-    #
-    # Permissions: rw_nus
-    #
-    # @see http://developer.linkedin.com/documents/commenting-reading-comments-and-likes-network-updates
-    #
-    # @param [String] update_key a update/update-key representing a
-    #   particular network update
-    # @macro profile_options
-    # @return [LinkedIn::Mash]
-    def share_comments(update_key, options={})
-      path = "#{profile_path(options)}/network/updates/key=#{update_key}/update-comments"
-      get(path, options)
-    end
-
-    # Retrieve all likes for a particular network update
-    #
-    # @note Some likes are included in the response to #network_updates
-    #
-    # Permissions: rw_nus
-    #
-    # @see http://developer.linkedin.com/documents/commenting-reading-comments-and-likes-network-updates
-    #
-    # @param [String] update_key a update/update-key representing a
-    #   particular network update
-    # @macro profile_options
-    # @return [LinkedIn::Mash]
-    def share_likes(update_key, options={})
-      path = "#{profile_path(options)}/network/updates/key=#{update_key}/likes"
-      get(path, options)
-    end
-
-    # Create a share for the authenticated user
-    #
-    # Permissions: rw_nus
-    #
-    # @see http://developer.linkedin.com/documents/share-api
-    #
-    # @macro share_input_fields
     # @return [void]
-    def add_share(share)
-      path = "/people/~/shares"
-      defaults = {visibility: {code: "anyone"}}
-      post(path, MultiJson.dump(defaults.merge(share)), "Content-Type" => "application/json")
-    end
-
-    # Create a comment on an update from the authenticated user
-    #
-    # @see http://developer.linkedin.com/documents/commenting-reading-comments-and-likes-network-updates
-    #
-    # @param [String] update_key a update/update-key representing a
-    #   particular network update
-    # @param [String] comment The text of the comment
-    # @return [void]
-    def update_comment(update_key, comment)
-      path = "/people/~/network/updates/key=#{update_key}/update-comments"
-      post(path, {comment: comment})
-    end
-
-    # (Update) like an update as the authenticated user
-    #
-    # @see http://developer.linkedin.com/documents/commenting-reading-comments-and-likes-network-updates
-    #
-    # @param [String] update_key a update/update-key representing a
-    #   particular network update
-    # @return [void]
-    def like_share(update_key)
-      path = "/people/~/network/updates/key=#{update_key}/is-liked"
-      put(path, "true")
-    end
-
-    # (Destroy) unlike an update the authenticated user previously
-    # liked
-    #
-    # @see http://developer.linkedin.com/documents/commenting-reading-comments-and-likes-network-updates
-    #
-    # @param [String] update_key a update/update-key representing a
-    #   particular network update
-    # @return [void]
-    def unlike_share(update_key)
-      path = "/people/~/network/updates/key=#{update_key}/is-liked"
-      put(path, "false")
+    def add_text_share(authorId, text)
+      path = "/ugcPosts"
+      params = {
+        "author" => authorId,
+        "lifecycleState" => "published",
+        "specificContent" => {
+          "com.linkedin.ugc.ShareContent" => {
+            "shareCommentary" => {
+              "text" => text
+            },
+            "shareMediaCategory" => "NONE"
+          }
+        },
+        "visibility" => {
+          "com.linkedin.ugc.MemberNetworkVisibility" => "PUBLIC"
+        }
+      }
+      post(path, params, "Content-Type" => "application/json")
     end
   end
 end

--- a/lib/linked_in/share_and_social_stream.rb
+++ b/lib/linked_in/share_and_social_stream.rb
@@ -28,7 +28,7 @@ module LinkedIn
           "com.linkedin.ugc.MemberNetworkVisibility" => "PUBLIC"
         }
       }
-      post(path, params, "Content-Type" => "application/json")
+      post(path, params.to_json, "Content-Type" => "application/json")
     end
   end
 end

--- a/lib/linked_in/share_and_social_stream.rb
+++ b/lib/linked_in/share_and_social_stream.rb
@@ -15,7 +15,7 @@ module LinkedIn
       path = "/ugcPosts"
       params = {
         "author" => authorId,
-        "lifecycleState" => "published",
+        "lifecycleState" => "PUBLISHED",
         "specificContent" => {
           "com.linkedin.ugc.ShareContent" => {
             "shareCommentary" => {

--- a/lib/linkedin-oauth2.rb
+++ b/lib/linkedin-oauth2.rb
@@ -33,6 +33,7 @@ require "linked_in/groups"
 require "linked_in/companies"
 require "linked_in/communications"
 require "linked_in/share_and_social_stream"
+require "linked_in/organizations"
 
 # The primary API object that makes requests.
 # It composes in all of the endpoints

--- a/spec/linked_in/api/companies_spec.rb
+++ b/spec/linked_in/api/companies_spec.rb
@@ -14,6 +14,11 @@ describe LinkedIn::Companies do
     expect(api.company(id: 1586)).to be_an_instance_of(LinkedIn::Mash)
   end
 
+  it "retrieves a company page with requested profile fields" do
+    stub("https://api.linkedin.com/v1/companies/1586:(id,name,description,logo-url)?")
+    expect(api.company(id: 1586, profile_fields: "id,name,description,logo-url")).to be_an_instance_of(LinkedIn::Mash)
+  end
+
   it "should be able to view a company by universal name" do
     stub("https://api.linkedin.com/v1/companies/universal-name=acme?")
     expect(api.company(name: "acme")).to be_an_instance_of(LinkedIn::Mash)


### PR DESCRIPTION
Needed to be able to pull specific company profile fields when retrieving a company. This pull request allows the `#company` method to accept an additional options parameter called `profile_fields` that is a comma delimited list of fields to retrieve (full list of profile field options found here: https://developer.linkedin.com/docs/fields/company-profile).
