### PR TITLE
Add default header {x-li-src: msdk} that it works with linkined api

### DIFF
--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -79,7 +79,10 @@ module LinkedIn
 
     def default_headers
       # https://developer.linkedin.com/documents/api-requests-json
-      return {"x-li-format" => "json"}
+      return {
+        "x-li-format" => "json",
+        "x-li-src" => "msdk"
+      }
     end
 
     def verify_access_token!(access_token)


### PR DESCRIPTION
Otherwise access token in header does not work (anymore?)

See here for details:
https://stackoverflow.com/questions/31751441/linkedin-verify-oauth2-access-token-on-server-side
https://stackoverflow.com/questions/28094926/linkedin-oauth2-unable-to-verify-access-token