### PR TITLE
Send access_token in header instead of query problem

### DIFF
--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -83,8 +83,7 @@ module LinkedIn
       access_token_header = "Bearer #{@access_token.token}"
       return {
         "Authorization" => access_token_header,
-        "x-li-format" => "json",
-        "x-li-src" => "msdk"
+        "x-li-format" => "json"
       }
     end
 

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -79,7 +79,10 @@ module LinkedIn
 
     def default_headers
       # https://developer.linkedin.com/documents/api-requests-json
-      return {"x-li-format" => "json"}
+      return {
+        "x-li-format" => "json",
+        "x-li-src" => "msdk"
+      }
     end
 
     def verify_access_token!(access_token)

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -74,12 +74,15 @@ module LinkedIn
 
     def default_params
       # https//developer.linkedin.com/documents/authentication
-      return {oauth2_access_token: @access_token.token}
+      return {}
     end
 
     def default_headers
       # https://developer.linkedin.com/documents/api-requests-json
+      #
+      access_token_header = "Bearer #{@access_token.token}"
       return {
+        "Authorization" => access_token_header,
         "x-li-format" => "json",
         "x-li-src" => "msdk"
       }


### PR DESCRIPTION
Sending access token in query param returns status 401 for me.

https://stackoverflow.com/questions/31751441/linkedin-verify-oauth2-access-token-on-server-sidehttps://stackoverflow.com/questions/28094926/linkedin-oauth2-unable-to-verify-access-token

Sending in header works for me.
Note: I am using an access token acquired from mobile SDK