### PR TITLE
Add support for tokens from the Mobile SDK

### DIFF
--- a/spec/linked_in/api/api_spec.rb
+++ b/spec/linked_in/api/api_spec.rb
@@ -38,4 +38,13 @@ describe LinkedIn::API do
 
     include_examples "test access token"
   end
+
+  context "With a string access token and `is_mobil_sdk` turned on" do
+    let(:access_token) { "dummy_access_token" }
+    let(:options) {{ is_mobile_sdk: true }}
+
+    subject {LinkedIn::API.new(access_token, options)}
+
+    include_examples "test access token"
+  end
 end


### PR DESCRIPTION
Hello,

this PR adds a new option called `is_mobile_sdk` to the contructor of `LinkedIn::API`.
When turned on, this allows to contact LinkedIn with the tokens obtained through the [Mobile SDK](https://developer.linkedin.com/docs/ios-sdk).

Basically, the usual approach to provide credentials (`oauth2_access_token`) does not work with these tokens, and you have to provide an "Authorization" header (+ a set of additional headers) to authenticate with the service.

We have this code running in Production with no issue.