### PR TITLE
Avoid duplicate redirect_uri keys

### DIFF
--- a/lib/linked_in/connection.rb
+++ b/lib/linked_in/connection.rb
@@ -16,8 +16,8 @@ module LinkedIn
       # We need to use the FlatParamsEncoder so we can pass multiple of
       # the same param to certain endpoints (like the search API).
       self.options.params_encoder = ::Faraday::FlatParamsEncoder
-
-      self.response :linkedin_raise_error
+      middleware = Faraday::RackBuilder::Handler.new(LinkedIn::RaiseError)
+      self.builder.handlers.push(middleware)
     end
 
 

--- a/lib/linked_in/oauth2.rb
+++ b/lib/linked_in/oauth2.rb
@@ -125,7 +125,7 @@ module LinkedIn
         check_access_code_url!(options)
       end
 
-      tok = self.auth_code.get_token(code, options)
+      tok = self.auth_code.get_token(code, options.stringify_keys)
       self.access_token = LinkedIn::AccessToken.new(tok.token,
                                                     tok.expires_in,
                                                     tok.expires_at)

--- a/linkedin-oauth2.gemspec
+++ b/linkedin-oauth2.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |gem|
   # To support native JSON. Same requirements as Rails.
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_dependency "oauth2",  "~> 1.0"
+  gem.add_dependency "oauth2"
   gem.add_dependency "hashie",  "~> 3.2"
-  gem.add_dependency "faraday", "~> 0.9"
+  gem.add_dependency "faraday", "~> 0.15.4"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Fixes error: invalid_request: Duplicate values defined for "redirect_uri" parameter