### PR TITLE
Grow 14773 update faraday 2

### DIFF
--- a/linkedin-oauth2.gemspec
+++ b/linkedin-oauth2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "oauth2",  "~> 1.0"
   gem.add_dependency "hashie",  "~> 3.2"
-  gem.add_dependency "faraday", "~> 0.9"
+  gem.add_dependency "faraday", "~> 1.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.0"

--- a/linkedin-oauth2.gemspec
+++ b/linkedin-oauth2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "oauth2",  "~> 1.0"
   gem.add_dependency "hashie",  "~> 3.2"
-  gem.add_dependency "faraday", "~> 1.0"
+  gem.add_dependency "faraday", "~> 2.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Updating to faraday 2 as part of our rails upgrade to 6.1 (which is needed to be compliant with Facebook and SOC2)